### PR TITLE
Add legacy ids

### DIFF
--- a/db/migrations/20191027201232_add-legacy-ids.js
+++ b/db/migrations/20191027201232_add-legacy-ids.js
@@ -1,0 +1,10 @@
+exports.up = async function (knex) {
+    await knex.schema.createTable('legacy_ids', function (t) {
+        t.string('id').primary().unique();
+        t.string('target').notNullable();
+    });
+};
+
+exports.down = async function (knex) {
+    await knex.schema.dropTable('legacy_ids');
+};

--- a/db/seeds/data/legacy_ids.yml
+++ b/db/seeds/data/legacy_ids.yml
@@ -1,0 +1,2 @@
+- id: discordbots.org
+  target: top.gg

--- a/db/seeds/data/lists.yml
+++ b/db/seeds/data/lists.yml
@@ -581,7 +581,7 @@
   content: null
   owners: DetectiveHuman#1234 (449653897695461376)
   discord: https://discord.gg/9jJtKRc
-- id: discordbots.org
+- id: top.gg
   added: 1532965633
   name: Discord Bot List
   url: https://top.gg/

--- a/db/seeds/legacy_ids.js
+++ b/db/seeds/legacy_ids.js
@@ -1,0 +1,5 @@
+const seedsImport = require('../seedsImport');
+
+exports.seed = async function (knex) {
+    await seedsImport(knex, 'legacy_ids');
+};

--- a/src/Dynamic/Includes/forms/legacy_ids.pug
+++ b/src/Dynamic/Includes/forms/legacy_ids.pug
@@ -1,0 +1,27 @@
+if errors && errors.length > 0
+    .notification.is-danger
+        button.delete
+        ul
+            for error in errors
+                li #{error}
+
+form(method='POST')
+    div#legacy-ids
+        for legacy in [...data, {id:'template', target:''}]
+            .media(id=`outer_${legacy.id}`, style=`${legacy.id === 'template' ? 'display: none;' : ''}`)
+                .media-left
+                    .field
+                        label.label Legacy ID:
+                        .control
+                            code #{legacy.id}
+                .media-content
+                    .field
+                        label.label(for=legacy.id) Target ID:
+                        .control
+                            input.input(type='text', id=legacy.id, name=legacy.id, value=legacy.target, required)
+                .media-right.button-group.button-group-vertical
+                    a.button.is-light.is-small(data-type='remove', data-target=`outer_${legacy.id}`, style='margin-top: 3em') Remove
+
+    .control
+        button.button.is-brand Submit
+

--- a/src/Dynamic/Includes/forms/legacy_ids.pug
+++ b/src/Dynamic/Includes/forms/legacy_ids.pug
@@ -18,10 +18,10 @@ form(method='POST')
                     .field
                         label.label(for=legacy.id) Target ID:
                         .control
-                            input.input(type='text', id=legacy.id, name=legacy.id, value=legacy.target, required)
+                            input.input(type='text', id=legacy.id, name=legacy.id, value=legacy.target, required=(legacy.id !== 'template'))
                 .media-right.button-group.button-group-vertical
                     a.button.is-light.is-small(data-type='remove', data-target=`outer_${legacy.id}`, style='margin-top: 3em') Remove
 
     .control
-        button.button.is-brand Submit
+        button.button.is-brand(type="submit") Submit
 

--- a/src/Dynamic/api/docs.pug
+++ b/src/Dynamic/api/docs.pug
@@ -17,6 +17,8 @@ block content
                                             a(href='#bots') Get bot information from lists
                                         li
                                             a(href='#lists') Get all lists' API details
+                                        li
+                                            a(href='#legacy-ids') Get all #{__('site_name')} legacy IDs
                                     p.menu-label Other
                                     ul.menu-list
                                         li
@@ -44,6 +46,8 @@ block content
                     include parts/bots
                 .card.is-box-shadow
                     include parts/lists
+                .card.is-box-shadow
+                    include parts/legacy_ids
                 .card.is-box-shadow
                     include parts/errors
                 .card.is-box-shadow

--- a/src/Dynamic/api/parts/legacy_ids.pug
+++ b/src/Dynamic/api/parts/legacy_ids.pug
@@ -1,0 +1,28 @@
+.card-content
+    h1.is-size-4.has-text-grey-lighter#lists Get all #{__('site_name')} legacy IDs
+        a(href='#legacy-ids')  &supdsub;
+    h6.is-size-6
+        a(href='/api/legacy-ids', target='_blank', rel='nofollow')
+            code GET /api/legacy-ids
+    h5.is-size-5 Response Body
+    .table-container
+        table.table.is-bordered.is-narrow
+            thead
+                tr
+                    th JSON Property
+                    th Type
+                    th Description
+            tbody
+                tr
+                    td &lt;legacy_id&gt;
+                    td String
+                    td The active list ID (the value) in #{__('site_name')} that the legacy ID (the key) maps to.
+    h5.is-size-5 Example Response
+    h6.is-size-6
+        a(href='/api/legacy-ids', target='_blank', rel='nofollow')
+            code GET /api/legacy-ids
+        pre
+            code.
+                {
+                    "oldlistdomain.com": "newlistdomain.com",
+                }

--- a/src/Dynamic/lists/legacy_ids.pug
+++ b/src/Dynamic/lists/legacy_ids.pug
@@ -1,0 +1,55 @@
+extends ../layout
+block content
+    section.section
+        .container
+            .columns
+                .column.is-half-desktop.is-full-mobile
+                    .card.is-box-shadow
+                        .card-content
+                            include ../Includes/forms/legacy_ids
+
+                            br
+                            hr
+                            br
+                            .media
+                                .media-content
+                                    .field
+                                        label.label(for='new_legacy_id') New Legacy ID:
+                                        .control
+                                            input.input(type='text', id='new_legacy_id', name='new_legacy_id')
+                                .media-right.button-group.button-group-vertical
+                                    a.button.is-light.is-small(data-type='add', style='margin-top: 3em') Add
+
+block footer
+    script.
+        function addRemoveBinding(elm) {
+            elm.addEventListener('click', function () {
+                var outer = document.getElementById(this.getAttribute('data-target'));
+                if (!outer) return;
+                outer.parentElement.removeChild(outer);
+            });
+        }
+
+        document.querySelector('[data-type="add"]').addEventListener('click', function () {
+            // Get the new legacy ID and validate it doesn't already exist
+            var newId = document.getElementById('new_legacy_id').value;
+            if (!newId) return;
+            if (document.getElementById(newId)) return;
+
+            // Create the new form section from the template
+            var div = document.getElementById('outer_template').cloneNode(true);
+            div.style.display = '';
+            div.id = 'outer_' + newId;
+            div.querySelector('.media-left .field .control code').textContent = newId;
+            div.querySelector('.media-content .field label').setAttribute('for', newId);
+            div.querySelector('.media-content .field .control input').setAttribute('id', newId);
+            div.querySelector('.media-content .field .control input').setAttribute('name', newId);
+            div.querySelector('.media-right a[data-type="remove"]').setAttribute('data-target', div.id);
+            addRemoveBinding(div.querySelector('.media-right a[data-type="remove"]'));
+            document.getElementById('legacy-ids').appendChild(div);
+        });
+
+        var elms = document.querySelectorAll('[data-type="remove"]');
+        for (var i = 0; i < elms.length; i++) {
+            addRemoveBinding(elms[i]);
+        }

--- a/src/Dynamic/lists/legacy_ids.pug
+++ b/src/Dynamic/lists/legacy_ids.pug
@@ -44,6 +44,7 @@ block footer
             div.querySelector('.media-content .field label').setAttribute('for', newId);
             div.querySelector('.media-content .field .control input').setAttribute('id', newId);
             div.querySelector('.media-content .field .control input').setAttribute('name', newId);
+            div.querySelector('.media-content .field .control input').setAttribute('required', 'true');
             div.querySelector('.media-right a[data-type="remove"]').setAttribute('data-target', div.id);
             addRemoveBinding(div.querySelector('.media-right a[data-type="remove"]'));
             document.getElementById('legacy-ids').appendChild(div);

--- a/src/Routes/API.js
+++ b/src/Routes/API.js
@@ -7,6 +7,7 @@ const getBotInformation = require('../Util/getBotInformation');
 const getUserAgent = require('../Util/getUserAgent');
 const isSnowflake = require('../Util/isSnowflake');
 const { slugify, librarySlug } = require('../Util/slugs');
+const legacyListMap = require('../Util/legacyListMap');
 const Renderer = require('../Structure/Markdown');
 const { secret } = require('../../config.js');
 
@@ -164,7 +165,8 @@ class APIRoute extends BaseRoute {
                 .then(async (lists) => {
                     const data = Object.keys(req.body);
                     for (let i = 0; i < data.length; i++) {
-                        const list = lists.filter((l) => l.id === data[i])[0];
+                        const dataId = await legacyListMap(this.db, data[i]);
+                        const list = lists.filter((l) => l.id === dataId)[0];
                         if (list) {
                             let payload = {};
                             if (req.body.shards && list.api_shards) {

--- a/src/Routes/API.js
+++ b/src/Routes/API.js
@@ -99,6 +99,30 @@ class APIRoute extends BaseRoute {
                 });
         });
 
+        this.router.get('/legacy-ids', this.ratelimit.checkRatelimit(1, 1), (req, res) => {
+            this.db
+                .select('id', 'target')
+                .from('legacy_ids')
+                .orderBy([
+                    { column: 'id', order: 'desc' }
+                ])
+                .then((legacy) => {
+                    const data = legacy.reduce(function(result, item) {
+                        result[item.id] = item.target;
+                        return result;
+                    }, {});
+                    res.status(200).json({ ...data });
+                })
+                .catch((e) => {
+                    handleError(this.db, req.method, req.originalUrl, e.stack);
+                    res.status(500).json({
+                        error: true,
+                        status: 500,
+                        message: 'An unexpected database error occurred'
+                    });
+                });
+        });
+
         this.router.post('/count', this.ratelimit.checkRatelimit(1, 120), (req, res) => {
             if (!req.body.bot_id) return res.status(400).json({
                 error: true,

--- a/src/Routes/Lists.js
+++ b/src/Routes/Lists.js
@@ -269,6 +269,24 @@ class ListsRoute extends BaseRoute {
             }
         });
 
+        this.router.get('/legacy-ids', this.requiresAuth.bind(this), this.isMod.bind(this), (req, res) => {
+            try {
+                this.db.select().from('legacy_ids').then((data) => {
+                    res.render('lists/legacy_ids', {
+                        title: 'Legacy IDs',
+                        data
+                    });
+                });
+            } catch (e) {
+                handleError(this.db, req.method, req.originalUrl, e.stack);
+                res.status(500).render('error', { title: 'Database Error' });
+            }
+        });
+
+        // *************
+        // List ID specific routes
+        // *************
+
         this.router.get('/:id', (req, res) => {
             try {
                 legacyListMap(this.db, req.params.id).then((id) => {

--- a/src/Routes/Lists.js
+++ b/src/Routes/Lists.js
@@ -283,6 +283,24 @@ class ListsRoute extends BaseRoute {
             }
         });
 
+        this.router.post('/legacy-ids', this.requiresAuth.bind(this), this.isMod.bind(this), (req, res) => {
+            try {
+                this.db('legacy_ids').del().then(() => {
+                    if ('template' in req.body) delete req.body.template;
+                    const items = Object.entries(req.body).map(item => { return { id: item[0], target: item[1] }; });
+                    this.db('legacy_ids').insert(items).then(() => {
+                        res.render('lists/legacy_ids', {
+                            title: 'Legacy IDs',
+                            data: items
+                        });
+                    });
+                });
+            } catch (e) {
+                handleError(this.db, req.method, req.originalUrl, e.stack);
+                res.status(500).render('error', { title: 'Database Error' });
+            }
+        });
+
         // *************
         // List ID specific routes
         // *************

--- a/src/Routes/Lists.js
+++ b/src/Routes/Lists.js
@@ -3,6 +3,7 @@ const FormValidator = require('../Structure/FormValidator');
 const getListFeature = require('../Util/getListFeature');
 const getListFeatures = require('../Util/getListFeatures');
 const handleError = require('../Util/handleError');
+const legacyListMap = require('../Util/legacyListMap');
 
 class ListsRoute extends BaseRoute {
     constructor(client, db) {
@@ -270,19 +271,20 @@ class ListsRoute extends BaseRoute {
 
         this.router.get('/:id', (req, res) => {
             try {
-                this.db.select().from('lists').where({ id: req.params.id }).limit(1).then((lists) => {
-                    if (!lists.length) return res.status(404).render('error', {
-                        title: 'Page not found',
-                        status: 404,
-                        message: 'The page you were looking for could not be found.'
-                    });
-                    getListFeatures(this.db, lists[0].id).then((features) => {
-
-                        res.render('lists/list', {
-                            title: `${lists[0].name} (${lists[0].id})`,
-                            list: lists[0],
-                            checkboxes: features,
-                            hideUncheckedBoxes: true
+                legacyListMap(this.db, req.params.id).then((id) => {
+                    this.db.select().from('lists').where({ id }).limit(1).then((lists) => {
+                        if (!lists.length) return res.status(404).render('error', {
+                            title: 'Page not found',
+                            status: 404,
+                            message: 'The page you were looking for could not be found.'
+                        });
+                        getListFeatures(this.db, lists[0].id).then((features) => {
+                            res.render('lists/list', {
+                                title: `${lists[0].name} (${lists[0].id})`,
+                                list: lists[0],
+                                checkboxes: features,
+                                hideUncheckedBoxes: true
+                            });
                         });
                     });
                 });
@@ -294,21 +296,23 @@ class ListsRoute extends BaseRoute {
 
         this.router.get('/:id/edit', this.requiresAuth.bind(this), this.isMod.bind(this), (req, res) => {
             try {
-                this.db.select().from('lists').where({ id: req.params.id }).limit(1).then((lists) => {
-                    if (!lists.length) return res.status(404).render('error', {
-                        title: 'Page not found',
-                        status: 404,
-                        message: 'The page you were looking for could not be found.'
-                    });
-                    getListFeatures(this.db, lists[0].id).then((features) => {
+                legacyListMap(this.db, req.params.id).then((id) => {
+                    this.db.select().from('lists').where({ id }).limit(1).then((lists) => {
+                        if (!lists.length) return res.status(404).render('error', {
+                            title: 'Page not found',
+                            status: 404,
+                            message: 'The page you were looking for could not be found.'
+                        });
+                        getListFeatures(this.db, lists[0].id).then((features) => {
 
-                        res.render('lists/edit', {
-                            title: 'Edit ' + lists[0].id,
-                            data: lists[0],
-                            checkboxes: features,
-                            edit: true,
-                            hideUncheckedBoxes: false,
-                            interactiveCheckboxes: true
+                            res.render('lists/edit', {
+                                title: 'Edit ' + lists[0].id,
+                                data: lists[0],
+                                checkboxes: features,
+                                edit: true,
+                                hideUncheckedBoxes: false,
+                                interactiveCheckboxes: true
+                            });
                         });
                     });
                 });
@@ -320,70 +324,72 @@ class ListsRoute extends BaseRoute {
 
         this.router.post('/:id/edit', this.requiresAuth.bind(this), this.isMod.bind(this), (req, res) => {
             try {
-                this.db.select().from('lists').where({ id: req.params.id }).limit(1).then((lists) => {
-                    if (!lists.length) return res.status(404).render('error', {
-                        title: 'Page not found',
-                        status: 404,
-                        message: 'The page you were looking for could not be found.'
-                    });
-                    getListFeatures(this.db, lists[0].id).then(async (features) => {
-
-                        const validate = FormValidator.validateList(req.params.id, req.body, res.locals.user);
-                        let changes = {};
-                        let addedFeatures = [];
-                        if (validate && validate.length > 0) return res.render('lists/edit', {
-                            title: 'Edit ' + lists[0].id,
-                            data: lists[0],
-                            checkboxes: features,
-                            edit: true,
-                            hideUncheckedBoxes: false,
-                            interactiveCheckboxes: true,
-                            errors: validate
+                legacyListMap(this.db, req.params.id).then((id) => {
+                    this.db.select().from('lists').where({ id }).limit(1).then((lists) => {
+                        if (!lists.length) return res.status(404).render('error', {
+                            title: 'Page not found',
+                            status: 404,
+                            message: 'The page you were looking for could not be found.'
                         });
-                        try {
-                            const columns = Object.keys(await this.db('lists').columnInfo());
-                            for (const column of columns) {
-                                if (req.body[column]) {
-                                    changes[column] = req.body[column];
-                                } else {
-                                    changes[column] = null;
-                                }
-                            }
-                            changes['added'] = lists[0].added;
-                            await this.db('lists').where({ id: req.params.id }).del();
-                            await this.db('lists').insert(changes);
+                        getListFeatures(this.db, lists[0].id).then(async (features) => {
 
-                            const oldFeatures = await this.db.select().from('feature_map').where({
-                                list: req.params.id,
-                                value: true
+                            const validate = FormValidator.validateList(id, req.body, res.locals.user);
+                            let changes = {};
+                            let addedFeatures = [];
+                            if (validate && validate.length > 0) return res.render('lists/edit', {
+                                title: 'Edit ' + lists[0].id,
+                                data: lists[0],
+                                checkboxes: features,
+                                edit: true,
+                                hideUncheckedBoxes: false,
+                                interactiveCheckboxes: true,
+                                errors: validate
                             });
-                            await this.db('feature_map').where({ list: req.params.id }).del();
-                            for (let [key, value] of Object.entries(req.body)) {
-                                if (key.substring(0, 8) === 'feature_') {
-                                    key = key.replace('feature_', '');
-                                    value = value === 'on';
-                                    await this.db('feature_map').insert({
-                                        list: changes.id,
-                                        feature: key,
-                                        value
-                                    });
-                                    if (value) {
-                                        addedFeatures.push(Number(key));
+                            try {
+                                const columns = Object.keys(await this.db('lists').columnInfo());
+                                for (const column of columns) {
+                                    if (req.body[column]) {
+                                        changes[column] = req.body[column];
+                                    } else {
+                                        changes[column] = null;
                                     }
                                 }
+                                changes['added'] = lists[0].added;
+                                await this.db('lists').where({ id }).del();
+                                await this.db('lists').insert(changes);
+
+                                const oldFeatures = await this.db.select().from('feature_map').where({
+                                    list: id,
+                                    value: true
+                                });
+                                await this.db('feature_map').where({ list: id }).del();
+                                for (let [key, value] of Object.entries(req.body)) {
+                                    if (key.substring(0, 8) === 'feature_') {
+                                        key = key.replace('feature_', '');
+                                        value = value === 'on';
+                                        await this.db('feature_map').insert({
+                                            list: changes.id,
+                                            feature: key,
+                                            value
+                                        });
+                                        if (value) {
+                                            addedFeatures.push(Number(key));
+                                        }
+                                    }
+                                }
+                                this.client.updateEditLog(
+                                    lists[0],
+                                    changes,
+                                    await Promise.all(addedFeatures.map((f) => getListFeature(this.db, Number(f)))),
+                                    await Promise.all(oldFeatures.map((f) => getListFeature(this.db, Number(f.feature))))
+                                );
+                                require('../Util/updateListMessage')(this.client, this.db, changes, changes['id']);
+                                res.redirect('/lists/' + changes.id);
+                            } catch (e) {
+                                handleError(this.db, req.method, req.originalUrl, e.stack);
+                                res.status(500).render('error', { title: 'Database Error' });
                             }
-                            this.client.updateEditLog(
-                                lists[0],
-                                changes,
-                                await Promise.all(addedFeatures.map((f) => getListFeature(this.db, Number(f)))),
-                                await Promise.all(oldFeatures.map((f) => getListFeature(this.db, Number(f.feature))))
-                            );
-                            require('../Util/updateListMessage')(this.client, this.db, changes, changes['id']);
-                            res.redirect('/lists/' + changes.id);
-                        } catch (e) {
-                            handleError(this.db, req.method, req.originalUrl, e.stack);
-                            res.status(500).render('error', { title: 'Database Error' });
-                        }
+                        });
                     });
                 });
             } catch (e) {
@@ -394,7 +400,8 @@ class ListsRoute extends BaseRoute {
 
         this.router.get('/:id/icon', this.requiresAuth.bind(this), this.isMod.bind(this), async (req, res) => {
             try {
-                const lists = await this.db.select().from('lists').where({ id: req.params.id }).limit(1);
+                const id = await legacyListMap(this.db, req.params.id);
+                const lists = await this.db.select().from('lists').where({ id }).limit(1);
                 if (!lists.length) return res.status(404).render('error', {
                     title: 'Page not found',
                     status: 404,

--- a/src/Util/legacyListMap.js
+++ b/src/Util/legacyListMap.js
@@ -1,0 +1,5 @@
+module.exports = async (db, id) => {
+    const res = await db.select('target').from('legacy_ids').where({ id });
+    if (res.length) return res[0].target;
+    return id;
+};

--- a/src/Util/legacyListMap.js
+++ b/src/Util/legacyListMap.js
@@ -1,5 +1,5 @@
 module.exports = async (db, id) => {
-    const res = await db.select('target').from('legacy_ids').where({ id });
+    const res = await db.select('target').from('legacy_ids').where({ id }).limit(1);
     if (res.length) return res[0].target;
     return id;
 };

--- a/test/Routes/API.js
+++ b/test/Routes/API.js
@@ -570,7 +570,7 @@ describe('/api/count', () => {
             describe('Legacy list ID with fake token', () => {
                 let id, target, test;
                 before('fetch list data', done => {
-                    db.select().from('legacy_ids').then(legacy => {
+                    db.select().from('legacy_ids').limit(1).then(legacy => {
                         id = legacy[0].id;
                         target = legacy[0].target;
                         const data = {
@@ -593,8 +593,9 @@ describe('/api/count', () => {
                 });
                 it('contains the correct target id for the legacy id', done => {
                     test().end((err, res) => {
-                        expect({...res.body.success, ...res.body.failure}).to.have.property(target);
-                        expect({...res.body.success, ...res.body.failure}).to.not.have.property(id);
+                        const keys = [...Object.keys(res.body.success), ...Object.keys(res.body.failure)];
+                        expect(keys).to.contain(target);
+                        expect(keys).to.not.contain(id);
                         done();
                     });
                 });

--- a/test/Routes/Lists.js
+++ b/test/Routes/Lists.js
@@ -431,10 +431,10 @@ describe('/lists/:id', () => {
     describe('GET Legacy ID', () => {
         let id, target, data;
         before('fetch list data', done => {
-            db.select().from('legacy_ids').then(legacy => {
+            db.select().from('legacy_ids').limit(1).then(legacy => {
                 id = legacy[0].id;
                 target = legacy[0].target;
-                db.select().from('lists').where({ id: target }).then(lists => {
+                db.select().from('lists').where({ id: target }).limit(1).then(lists => {
                     data = lists[0];
                     done();
                 });

--- a/test/Routes/Lists.js
+++ b/test/Routes/Lists.js
@@ -469,3 +469,125 @@ describe('/lists/:id', () => {
         });
     });
 });
+
+describe('/lists/:id/edit', () => {
+    const listId = 'botlist.space';
+    describe(`GET (:id = ${listId})`, () => {
+        const test = () => request().get(`/lists/${listId}/edit`);
+        it('returns a Forbidden status code', done => {
+            test().end((err, res) => {
+                expect(res).to.have.status(403);
+                done();
+            });
+        });
+        it('renders the authentication required message', done => {
+            test().end((err, res) => {
+                authCheck(res);
+                done();
+            });
+        });
+    });
+
+    describe(`POST (:id = ${listId})`, () => {
+        const test = () => request().post(`/lists/${listId}/edit`);
+        it('returns a Forbidden status code', done => {
+            test().end((err, res) => {
+                expect(res).to.have.status(403);
+                done();
+            });
+        });
+        it('renders the authentication required message', done => {
+            test().end((err, res) => {
+                authCheck(res);
+                done();
+            });
+        });
+    });
+});
+
+describe('/lists/:id/icon', () => {
+    const listId = 'botlist.space';
+    describe(`GET (:id = ${listId})`, () => {
+        const test = () => request().get(`/lists/${listId}/icon`);
+        it('returns a Forbidden status code', done => {
+            test().end((err, res) => {
+                expect(res).to.have.status(403);
+                done();
+            });
+        });
+        it('renders the authentication required message', done => {
+            test().end((err, res) => {
+                authCheck(res);
+                done();
+            });
+        });
+    });
+});
+
+describe('/lists/add', () => {
+    describe('GET', () => {
+        const test = () => request().get('/lists/add');
+        it('returns a Forbidden status code', done => {
+            test().end((err, res) => {
+                expect(res).to.have.status(403);
+                done();
+            });
+        });
+        it('renders the authentication required message', done => {
+            test().end((err, res) => {
+                authCheck(res);
+                done();
+            });
+        });
+    });
+
+    describe('POST', () => {
+        const test = () => request().post('/lists/add');
+        it('returns a Forbidden status code', done => {
+            test().end((err, res) => {
+                expect(res).to.have.status(403);
+                done();
+            });
+        });
+        it('renders the authentication required message', done => {
+            test().end((err, res) => {
+                authCheck(res);
+                done();
+            });
+        });
+    });
+});
+
+describe('/lists/legacy-ids', () => {
+    describe('GET', () => {
+        const test = () => request().get('/lists/legacy-ids');
+        it('returns a Forbidden status code', done => {
+            test().end((err, res) => {
+                expect(res).to.have.status(403);
+                done();
+            });
+        });
+        it('renders the authentication required message', done => {
+            test().end((err, res) => {
+                authCheck(res);
+                done();
+            });
+        });
+    });
+
+    describe('POST', () => {
+        const test = () => request().post('/lists/legacy-ids');
+        it('returns a Forbidden status code', done => {
+            test().end((err, res) => {
+                expect(res).to.have.status(403);
+                done();
+            });
+        });
+        it('renders the authentication required message', done => {
+            test().end((err, res) => {
+                authCheck(res);
+                done();
+            });
+        });
+    });
+});

--- a/test/Routes/Lists.js
+++ b/test/Routes/Lists.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, request, db, locale, titleCheck } = require('../base');
+const { describe, it, expect, request, db, locale, titleCheck, authCheck } = require('../base');
 
 describe('/lists', () => {
     describe('GET', () => {

--- a/test/Routes/Lists.js
+++ b/test/Routes/Lists.js
@@ -428,6 +428,29 @@ describe('/lists/:id', () => {
         });
     });
 
+    describe('GET Legacy ID', () => {
+        let id, target, data;
+        before('fetch list data', done => {
+            db.select().from('legacy_ids').then(legacy => {
+                id = legacy[0].id;
+                target = legacy[0].target;
+                db.select().from('lists').where({ id: target }).then(lists => {
+                    data = lists[0];
+                    done();
+                });
+            });
+        });
+        it('returns the target list page', done => {
+            const test = () => request().get(`/lists/${id}`);
+            test().end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res).to.be.html;
+                titleCheck(res, `${data.name} (${data.id}) - ${locale('site_name')} - ${locale('short_desc')}`);
+                done();
+            });
+        });
+    });
+
     describe('GET Invalid (:id = helloworld)', () => {
         const test = () => request().get('/lists/helloworld');
         it('returns a Not Found status code', done => {

--- a/test/Util/legacyListMap.js
+++ b/test/Util/legacyListMap.js
@@ -3,7 +3,7 @@ const legacyListMap = require('../../src/Util/legacyListMap');
 
 describe('legacyListMap', () => {
     it('converts a legacy ID to the target ID correctly', done => {
-        db.select().from('legacy_ids').then(legacy => {
+        db.select().from('legacy_ids').limit(1).then(legacy => {
             const id = legacy[0].id;
             const target = legacy[0].target;
             legacyListMap(db, id).then(test => {

--- a/test/Util/legacyListMap.js
+++ b/test/Util/legacyListMap.js
@@ -1,0 +1,15 @@
+const { describe, it, expect, db } = require('../base');
+const legacyListMap = require('../../src/Util/legacyListMap');
+
+describe('legacyListMap', () => {
+    it('converts a legacy ID to the target ID correctly', done => {
+        db.select().from('legacy_ids').then(legacy => {
+            const id = legacy[0].id;
+            const target = legacy[0].target;
+            legacyListMap(db, id).then(test => {
+                expect(test).to.equal(target);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
 - Add migration to create new `legacy_ids` table
 - Add backend logic to routes for supporting legacy IDs
   - /lists/:id/*
   - /api/count
 - Update seed data to make use of legacy IDs
 - Add tests for routes using legacy IDs