### PR TITLE
Fix list_messages when list ID is changed

### DIFF
--- a/src/Routes/Lists.js
+++ b/src/Routes/Lists.js
@@ -419,7 +419,7 @@ class ListsRoute extends BaseRoute {
                                     await Promise.all(addedFeatures.map((f) => getListFeature(this.db, Number(f)))),
                                     await Promise.all(oldFeatures.map((f) => getListFeature(this.db, Number(f.feature))))
                                 );
-                                require('../Util/updateListMessage')(this.client, this.db, changes, changes['id']);
+                                require('../Util/updateListMessage')(this.client, this.db, changes, id);
                                 res.redirect('/lists/' + changes.id);
                             } catch (e) {
                                 handleError(this.db, req.method, req.originalUrl, e.stack);

--- a/src/Util/updateListMessage.js
+++ b/src/Util/updateListMessage.js
@@ -1,19 +1,19 @@
 const formatListMessage = require('./formatListDiscordMessage');
 const config = require('../../config');
 
-module.exports = async (client, db, list, newListID) => {
+module.exports = async (client, db, list, oldListId) => {
     if (!config.discord.notifications) return;
     let msg;
     try {
         let message = formatListMessage(list);
-        const messageId = await db.select('message').from('lists_messages').where({ list: list.id });
+        const messageId = await db.select('message').from('lists_messages').where({ list: oldListId });
         if (messageId[0]) {
             msg = await client.editMessage(config.discord.lists_log, messageId[0].message, message);
         } else {
             msg = await client.createMessage(config.discord.lists_log, message);
         }
-        await db('lists_messages').where({ list: list.id }).del();
-        await db('lists_messages').insert( { list: newListID, message: msg.id });
+        await db('lists_messages').where({ list: oldListId }).del();
+        await db('lists_messages').insert( { list: list.id, message: msg.id });
     } catch {
         return null;
     }


### PR DESCRIPTION
Fixes #39 by passing in the correct old list ID into the list message function, so that changing a list ID will update the list_messages table correctly.