### PR TITLE
Fix the get bot cache

### DIFF
--- a/src/Util/getBotInformation.js
+++ b/src/Util/getBotInformation.js
@@ -8,10 +8,10 @@ module.exports = (endpoint, headers) => {
             timeout: 2 * 1000, // 2 Seconds,
             headers
         }).then((response) => {
-            resolve([ response.data, response.status ]);
+            resolve([ typeof response.data === 'object' ? response.data : null, response.status ]);
         }).catch((e) => {
             if (e.response) {
-                reject([ e.response.data, e.response.status ]);
+                reject([ typeof e.response.data === 'object' ? e.response.data : null, e.response.status ]);
             } else {
                 reject([ {}, 500 ]);
             }


### PR DESCRIPTION
Don't store anything that isn't an object that gets returned from list API endpoints, it breaks the cache as HTMl can be rather large.