### PR TITLE
Update API endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chai-http": "^4.3.0",
     "cookie-parser": "^1.4.4",
     "cookie-session": "^1.3.3",
+    "cors": "^2.8.5",
     "editorconfig-checker": "^3.0.3",
     "eslint": "^6.5.1",
     "express": "^4.17.1",

--- a/src/Dynamic/api/docs.pug
+++ b/src/Dynamic/api/docs.pug
@@ -40,5 +40,7 @@ block content
                         include parts/errors
                     .card.is-box-shadow
                         include parts/ratelimits
+                    .card.is-box-shadow
+                        include parts/cache
 block footer
     script(src='/assets/js/scroll.js')

--- a/src/Dynamic/api/includes/docs_sidebar.pug
+++ b/src/Dynamic/api/includes/docs_sidebar.pug
@@ -23,4 +23,6 @@ ul.menu-list
     li
         a(href='/api/docs#ratelimits') Ratelimits
     li
+        a(href='/api/docs#cache') Cache
+    li
         a(href='/api/docs/libs') API Libraries

--- a/src/Dynamic/api/parts/bots.pug
+++ b/src/Dynamic/api/parts/bots.pug
@@ -41,6 +41,26 @@
                     td String
                     td The invite URL for the bot (Discord or custom). *
                 tr
+                    td prefix
+                    td String
+                    td The command prefix for the bot. *
+                tr
+                    td website
+                    td String
+                    td The website link for the bot. *
+                tr
+                    td github
+                    td String
+                    td The open-source GitHub URL for the bot if it has one. *
+                tr
+                    td support
+                    td String
+                    td The support link for the bot (Discord or custom). *
+                tr
+                    td library
+                    td String
+                    td The library/language the bot was developed in. *
+                tr
                     td list_data
                     td Object&lt;Array&lt;Any, Integer&gt;&gt;
                     td Each list with a known bot GET API endpoint will have all its data returned along with the HTTP status code returned from the request under the key of the #{__('site_name')} ID for the list within the list_data property.
@@ -65,6 +85,11 @@
                     ],
                     "server_count": 500,
                     "invite": "https://discordapp.com/oauth2/authorize?client_id=123456789012345678&scope=bot&permissions=8",
+                    "prefix": "!",
+                    "website": "https://my-bot.com/",
+                    "github": "https://github.com/hello/my-bot",
+                    "support": "https://discord.gg/AbCdE9f",
+                    "library": "discord.js",
                     "list_data": {
                         "thelist.org": [
                             &lt;list data&gt;,

--- a/src/Dynamic/api/parts/cache.pug
+++ b/src/Dynamic/api/parts/cache.pug
@@ -1,0 +1,44 @@
+.card-content
+    h1.is-size-4.has-text-grey-lighter#cache Cache
+        a(href='#cache')  &supdsub;
+    p
+        | Certain API requests to BotBlock will be cached by the app to reduce load on upstream providers and our internal logic.
+        | Cache hit responses will not be affected by any ratelimits implemented within the app.
+    h5.is-size-5 Cached Endpoints
+    .table-container
+        table.table.is-bordered.is-narrow
+            thead
+                tr
+                    th Route
+                    th Request Type
+                    th Cache Expiry
+                    th Notes
+            tbody
+                tr
+                    td /api/bots/:id
+                    td GET
+                    td 300s
+                    td
+                        i Only successful requests will be cached.
+    h5.is-size-5 Response Body
+    p The following properties will be present in the JSON response alongside the original cached data.
+    .table-container
+        table.table.is-bordered.is-narrow
+            thead
+                tr
+                    th JSON Property
+                    th Type
+                    th Description
+            tbody
+                tr
+                    td cached
+                    td Boolean
+                    td This should always be #[code true] and indicates the response is from the app cache.
+                tr
+                    td cache_expires_at
+                    td Integer
+                    td The unix timestamp for when the cached response will expire.
+                tr
+                    td cache_expires_in
+                    td Integer
+                    td Seconds until the cached response expires, based on #[code cache_expires_at].

--- a/src/Dynamic/api/parts/ratelimits.pug
+++ b/src/Dynamic/api/parts/ratelimits.pug
@@ -28,13 +28,14 @@
                 tr
                     td /api/bots/:id
                     td GET
-                    td 1 / 30s
+                    td 1 / 30s *
                     td Yes (by URL)
                 tr
                     td /api/lists
                     td GET
                     td 1 / 1s
                     td No
+    p * Requests that hit the cache will not be ratelimited at all.
     h5.is-size-5 Response Body &amp; Headers
     h6.is-size-6
         code HTTP Status: 429 Too Many Requests

--- a/src/Dynamic/api/parts/ratelimits.pug
+++ b/src/Dynamic/api/parts/ratelimits.pug
@@ -28,14 +28,14 @@
                 tr
                     td /api/bots/:id
                     td GET
-                    td 1 / 30s *
+                    td 1 / 30s
                     td Yes (by URL)
                 tr
                     td /api/lists
                     td GET
                     td 1 / 1s
                     td No
-    p * Requests that hit the cache will not be ratelimited at all.
+    p Note: Any requests that hit #[a(href='#cache') the cache] will not be ratelimited at all.
     h5.is-size-5 Response Body &amp; Headers
     h6.is-size-6
         code HTTP Status: 429 Too Many Requests
@@ -57,7 +57,7 @@
                     td ratelimit_reset
                     td X-Rate-Limit-Reset
                     td Integer
-                    td How unix timestamp when the API can be used again.
+                    td The unix timestamp when the API can be used again.
                 tr
                     td ratelimit_ip
                     td X-Rate-Limit-IP

--- a/src/Dynamic/api/parts/ratelimits.pug
+++ b/src/Dynamic/api/parts/ratelimits.pug
@@ -29,7 +29,7 @@
                     td /api/bots/:id
                     td GET
                     td 1 / 30s
-                    td No
+                    td Yes (by URL)
                 tr
                     td /api/lists
                     td GET

--- a/src/Routes/API.js
+++ b/src/Routes/API.js
@@ -209,15 +209,12 @@ class APIRoute extends BaseRoute {
                 });
         });
 
-        this.router.get('/bots/:id', cors(), this.ratelimit.checkRatelimit(1, 30), async (req, res) => {
+        this.router.get('/bots/:id', cors(), this.cache.handler(), this.ratelimit.checkRatelimit(1, 30), async (req, res) => {
             if (!isSnowflake(req.params.id)) return res.status(400).json({
                 error: true,
                 status: 400,
                 message: '\'id\' must be a snowflake'
             });
-            await this.cache.deleteExpired();
-            const cache = await this.cache.get(req.originalUrl);
-            if (cache) return res.status(200).json({ ...JSON.parse(cache.data), cached: true });
             let lists = [];
             let output = {
                 id: String(req.params.id),

--- a/src/Routes/API.js
+++ b/src/Routes/API.js
@@ -226,6 +226,11 @@ class APIRoute extends BaseRoute {
                 owners: [],
                 server_count: [],
                 invite: [],
+                prefix: [],
+                website: [],
+                github: [],
+                support: [],
+                library: [],
                 list_data: lists
             };
             this.db.select('id', 'api_get').from('lists')
@@ -250,36 +255,64 @@ class APIRoute extends BaseRoute {
                     for (let list of Object.keys(lists)) {
                         list = lists[list];
                         if (Number(list[1]) === 200) {
+                            // TODO: discordsbestbots.xyz returns everything inside the 'bot' property of a parent object, we need to handle that
                             const fields = Object.keys(list[0]);
                             for (let key in fields) {
                                 key = fields[Number(key)].toLowerCase();
                                 const value = list[0][key];
                                 if (!value) continue;
-                                if (key === 'name' || key === 'username') {
+                                if (key === 'name' || key === 'username' || key === 'bot_name') {
                                     output.username.push(value);
                                 }
                                 if (key === 'discrim' || key === 'discriminator') {
                                     output.discriminator.push(String(value));
                                 }
-                                if (key === 'owner' || key === 'owners') {
+                                if (key === 'owner' || key === 'owners' || key === 'authors' || key === 'bot_owners') {
                                     if (!Array.isArray(value) && typeof value !== 'object') {
                                         output.owners.push(value);
                                     } else if (Array.isArray(value) && typeof value !== 'object') {
                                         for (const owner of value) {
-                                            if (!Array.isArray(owner) && typeof owner !== 'object' && !Array.isArray(owner)) {
+                                            if (!Array.isArray(owner) && typeof owner !== 'object') {
                                                 output.owners.push(owner);
+                                            } else if (typeof value === 'object') {
+                                                if (value['id']) output.owners.push(value['id']);
+                                                else if (value['userId']) output.owners.push(value['userId']);
                                             }
                                         }
                                     } else if (typeof value === 'object') {
                                         if (value['id']) output.owners.push(value['id']);
+                                        else if (value['userId']) output.owners.push(value['userId']);
                                     }
                                 }
-                                if (key === 'count' || key === 'servers' || key === 'server_count' || key === 'servercount' || key === 'guilds' || key === 'guild_count' || key === 'guildcount') {
+                                if (key === 'count' || key === 'servers' || key === 'server_count' || key === 'servercount' || key === 'serverCount'
+                                    || key === 'bot_server_count' || key === 'guilds' || key === 'guild_count' || key === 'guildcount' || key === 'guildCount') {
                                     const temp = parseInt(value);
                                     if (typeof temp === 'number') output.server_count.push(temp);
                                 }
-                                if (key === 'invite' || key === 'bot_invite') {
+                                if (key === 'links') {
+                                    if (typeof value === 'object') {
+                                        if (value['invite']) output.invite.push(value['invite']);
+                                        if (value['support']) output.support.push(value['support']);
+                                    }
+                                }
+                                if (key === 'invite' || key === 'bot_invite' || key === 'botInvite' || key === 'bot_invite_link') {
                                     if (typeof key === 'string') output.invite.push(value);
+                                }
+                                if (key === 'prefix' || key === 'bot_prefix') {
+                                    if (typeof key === 'string') output.prefix.push(value);
+                                }
+                                if (key === 'website' || key === 'bot_website') {
+                                    if (typeof key === 'string') output.website.push(value);
+                                }
+                                if (key === 'github' || key === 'bot_github_repo' || key === 'openSource' || key === 'git') {
+                                    if (typeof key === 'string') output.github.push(value);
+                                }
+                                if (key === 'support' || key === 'supportInvite' || key === 'support_server' || key === 'discord'
+                                    || key === 'server_invite' || key === 'bot_support_discord' || key === 'server') {
+                                    if (typeof key === 'string') output.support.push(value);
+                                }
+                                if (key === 'library' || key === 'libraryName' || key === 'bot_library' || key === 'lang') {
+                                    if (typeof key === 'string') output.library.push(value);
                                 }
                             }
                         }
@@ -288,9 +321,14 @@ class APIRoute extends BaseRoute {
                         id: output.id,
                         username: this.getMostCommon(output.username) || 'Unknown',
                         discriminator: this.getMostCommon(output.discriminator) || '0000',
-                        owners: output.owners || [],
+                        owners: output.owners.filter((v, i, a) => a.indexOf(v) === i && isSnowflake(v)) || [],
                         server_count: Math.max(...output.server_count) || 0,
                         invite: this.getMostCommon(output.invite) || '',
+                        prefix: this.getMostCommon(output.prefix) || '',
+                        website: this.getMostCommon(output.website) || '',
+                        github: this.getMostCommon(output.github) || '',
+                        support: this.getMostCommon(output.support) || '',
+                        library: this.getMostCommon(output.library) || '',
                         list_data: { ...lists } || {}
                     };
                     await this.cache.add(req.originalUrl, 300, response);

--- a/src/Routes/API.js
+++ b/src/Routes/API.js
@@ -1,3 +1,4 @@
+const cors = require('cors');
 const BaseRoute = require('../Structure/BaseRoute');
 const Ratelimiter = require('../Structure/RateLimiter');
 const Cache = require('../Structure/Cache');
@@ -58,7 +59,7 @@ class APIRoute extends BaseRoute {
             });
         });
 
-        this.router.get('/lists', this.ratelimit.checkRatelimit(1, 1), (req, res) => {
+        this.router.get('/lists', cors(), this.ratelimit.checkRatelimit(1, 1), (req, res) => {
             const data = {};
             this.db
                 .select('id', 'api_docs', 'api_post', 'api_field', 'api_shard_id', 'api_shard_count', 'api_shards', 'api_get')
@@ -92,7 +93,7 @@ class APIRoute extends BaseRoute {
                 });
         });
 
-        this.router.get('/legacy-ids', this.ratelimit.checkRatelimit(1, 1), (req, res) => {
+        this.router.get('/legacy-ids', cors(), this.ratelimit.checkRatelimit(1, 1), (req, res) => {
             this.db
                 .select('id', 'target')
                 .from('legacy_ids')
@@ -111,7 +112,7 @@ class APIRoute extends BaseRoute {
                 });
         });
 
-        this.router.post('/count', this.ratelimit.checkRatelimit(1, 120), (req, res) => {
+        this.router.post('/count', cors(), this.ratelimit.checkRatelimit(1, 120), (req, res) => {
             if (!req.body.bot_id) return res.status(400).json({
                 error: true,
                 status: 400,
@@ -208,7 +209,7 @@ class APIRoute extends BaseRoute {
                 });
         });
 
-        this.router.get('/bots/:id', this.ratelimit.checkRatelimit(1, 30), async (req, res) => {
+        this.router.get('/bots/:id', cors(), this.ratelimit.checkRatelimit(1, 30), async (req, res) => {
             if (!isSnowflake(req.params.id)) return res.status(400).json({
                 error: true,
                 status: 400,
@@ -311,12 +312,12 @@ class APIRoute extends BaseRoute {
             });
         });
 
-        this.router.use('*', (req, res) => {
+        this.router.use('*', cors(), (req, res) => {
             res.status(404).json({ error: true, status: 404, message: 'Endpoint not found' });
         });
 
 
-        this.router.use('*', (err, req, res) => {
+        this.router.use('*', cors(), (err, req, res) => {
             res.status(404).json({ error: true, status: 404, message: 'Endpoint not found' });
         });
     }

--- a/src/Structure/Cache.js
+++ b/src/Structure/Cache.js
@@ -22,7 +22,7 @@ class Cache {
         try {
             return await this.db('cache').insert({
                 route,
-                expiry: (Date.now() / 1000) + expiry,
+                expiry: Date.now() / 1000 + expiry,
                 data: JSON.stringify(data)
             });
         } catch {
@@ -46,10 +46,10 @@ class Cache {
                 ...JSON.parse(cache.data),
                 cached: true,
                 cache_expires_at: cache.expiry,
-                cache_expires_in: Math.round(cache.expiry - (Date.now() / 1000)),
+                cache_expires_in: Math.round(cache.expiry - Date.now() / 1000)
             });
             next();
-        }
+        };
     }
 }
 

--- a/src/Structure/Cache.js
+++ b/src/Structure/Cache.js
@@ -30,10 +30,6 @@ class Cache {
         }
     }
 
-    delete() {
-
-    }
-
     async deleteExpired() {
         try {
             return await this.db('cache').where('expiry', '<', new Date().getSeconds()).del();
@@ -42,9 +38,13 @@ class Cache {
         }
     }
 
-
-    getAll() {
-
+    handler() {
+        return async (req, res, next) => {
+            await this.deleteExpired();
+            const cache = await this.get(req.originalUrl);
+            if (cache) return res.status(200).json({ ...JSON.parse(cache.data), cached: true });
+            next();
+        }
     }
 }
 

--- a/src/Structure/Cache.js
+++ b/src/Structure/Cache.js
@@ -46,7 +46,7 @@ class Cache {
                 ...JSON.parse(cache.data),
                 cached: true,
                 cache_expires_at: cache.expiry,
-                cache_expires_in: cache.expiry - (Date.now() / 1000),
+                cache_expires_in: Math.round(cache.expiry - (Date.now() / 1000)),
             });
             next();
         }

--- a/test/Routes/API.js
+++ b/test/Routes/API.js
@@ -9,6 +9,12 @@ describe('Invalid route (/api/helloworld)', () => {
                 done();
             });
         });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                done();
+            });
+        });
         it('returns an error JSON body', done => {
             test().end((err, res) => {
                 expect(res).to.be.json;
@@ -25,6 +31,12 @@ describe('Invalid route (/api/helloworld)', () => {
         it('returns a Not Found status code', done => {
             test().end((err, res) => {
                 expect(res).to.have.status(404);
+                done();
+            });
+        });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                 done();
             });
         });
@@ -46,6 +58,12 @@ describe('/api/docs', () => {
         it('returns an OK status code', done => {
             test().end((err, res) => {
                 expect(res).to.have.status(200);
+                done();
+            });
+        });
+        it('has no CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.not.have.header('Access-Control-Allow-Origin');
                 done();
             });
         });
@@ -122,6 +140,78 @@ describe('/api/docs', () => {
                 done();
             });
         });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                done();
+            });
+        });
+        it('returns an error JSON body', done => {
+            test().end((err, res) => {
+                expect(res).to.be.json;
+                expect(res.body).to.have.property('error', true);
+                expect(res.body).to.have.property('status', 404);
+                expect(res.body).to.have.property('message', 'Endpoint not found');
+                done();
+            });
+        });
+    });
+});
+
+describe('/api/docs/libs', () => {
+    describe('GET', () => {
+        const test = () => request().get('/api/docs/libs');
+        it('returns an OK status code', done => {
+            test().end((err, res) => {
+                expect(res).to.have.status(200);
+                done();
+            });
+        });
+        it('has no CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.not.have.header('Access-Control-Allow-Origin');
+                done();
+            });
+        });
+        it('has the correct page title', done => {
+            test().end((err, res) => {
+                expect(res).to.be.html;
+                titleCheck(res, `Libraries - API Docs - ${locale('site_name')} - ${locale('short_desc')}`);
+                done();
+            });
+        });
+        it('renders the expected header content', done => {
+            test().end((err, res) => {
+                expect(res).to.be.html;
+
+                // Confirm header
+                expect(res.text).to.include('API Libraries');
+                expect(res.text).to.include('Some libraries have been written making use of');
+
+                // Confirm menu
+                expect(res.text).to.include('<aside class="menu">');
+                expect(res.text).to.include('<p class="menu-label">');
+                expect(res.text).to.include('<ul class="menu-list">');
+
+                done();
+            });
+        });
+    });
+
+    describe('POST', () => {
+        const test = () => request().post('/api/docs/libs');
+        it('returns a Not Found status code', done => {
+            test().end((err, res) => {
+                expect(res).to.have.status(404);
+                done();
+            });
+        });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                done();
+            });
+        });
         it('returns an error JSON body', done => {
             test().end((err, res) => {
                 expect(res).to.be.json;
@@ -140,6 +230,12 @@ describe('/api/lists', () => {
         it('returns an OK status code', done => {
             test().end((err, res) => {
                 expect(res).to.have.status(200);
+                done();
+            });
+        });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                 done();
             });
         });
@@ -178,6 +274,12 @@ describe('/api/lists', () => {
         it('returns an OK status code', done => {
             test().end((err, res) => {
                 expect(res).to.have.status(200);
+                done();
+            });
+        });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                 done();
             });
         });
@@ -242,6 +344,12 @@ describe('/api/lists', () => {
                 done();
             });
         });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                done();
+            });
+        });
         it('returns an error JSON body', done => {
             test().end((err, res) => {
                 expect(res).to.be.json;
@@ -260,6 +368,12 @@ describe('/api/count', () => {
         it('returns a Not Found status code', done => {
             test().end((err, res) => {
                 expect(res).to.have.status(404);
+                done();
+            });
+        });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                 done();
             });
         });
@@ -284,6 +398,12 @@ describe('/api/count', () => {
                         done();
                     });
                 });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                        done();
+                    });
+                });
                 it('returns a correct error JSON body', done => {
                     test().end((err, res) => {
                         expect(res).to.be.json;
@@ -300,6 +420,12 @@ describe('/api/count', () => {
                 it('returns a Bad Request status code', done => {
                     test().end((err, res) => {
                         expect(res).to.have.status(400);
+                        done();
+                    });
+                });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                         done();
                     });
                 });
@@ -325,6 +451,12 @@ describe('/api/count', () => {
                         done();
                     });
                 });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                        done();
+                    });
+                });
                 it('returns a correct error JSON body', done => {
                     test().end((err, res) => {
                         expect(res).to.be.json;
@@ -344,6 +476,12 @@ describe('/api/count', () => {
                 it('returns a Bad Request status code', done => {
                     test().end((err, res) => {
                         expect(res).to.have.status(400);
+                        done();
+                    });
+                });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                         done();
                     });
                 });
@@ -369,6 +507,12 @@ describe('/api/count', () => {
                         done();
                     });
                 });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                        done();
+                    });
+                });
                 it('returns a correct error JSON body', done => {
                     test().end((err, res) => {
                         expect(res).to.be.json;
@@ -387,6 +531,12 @@ describe('/api/count', () => {
                 it('returns a Bad Request status code', done => {
                     test().end((err, res) => {
                         expect(res).to.have.status(400);
+                        done();
+                    });
+                });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                         done();
                     });
                 });
@@ -409,6 +559,12 @@ describe('/api/count', () => {
                 it('returns a Bad Request status code', done => {
                     test().end((err, res) => {
                         expect(res).to.have.status(400);
+                        done();
+                    });
+                });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                         done();
                     });
                 });
@@ -435,6 +591,12 @@ describe('/api/count', () => {
                         done();
                     });
                 });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                        done();
+                    });
+                });
                 it('returns a correct error JSON body', done => {
                     test().end((err, res) => {
                         expect(res).to.be.json;
@@ -455,6 +617,12 @@ describe('/api/count', () => {
                 it('returns a Bad Request status code', done => {
                     test().end((err, res) => {
                         expect(res).to.have.status(400);
+                        done();
+                    });
+                });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                         done();
                     });
                 });
@@ -481,6 +649,12 @@ describe('/api/count', () => {
                         done();
                     });
                 });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                        done();
+                    });
+                });
                 it('returns a correct error JSON body', done => {
                     test().end((err, res) => {
                         expect(res).to.be.json;
@@ -501,6 +675,12 @@ describe('/api/count', () => {
                 it('returns a Bad Request status code', done => {
                     test().end((err, res) => {
                         expect(res).to.have.status(400);
+                        done();
+                    });
+                });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                         done();
                     });
                 });
@@ -525,6 +705,12 @@ describe('/api/count', () => {
                 it('returns an OK status code', done => {
                     test().end((err, res) => {
                         expect(res).to.have.status(200);
+                        done();
+                    });
+                });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                         done();
                     });
                 });
@@ -726,6 +912,12 @@ describe('/api/bots/:id', () => {
                         done();
                     });
                 });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                        done();
+                    });
+                });
                 it('returns an error JSON body', done => {
                     test().end((err, res) => {
                         expect(res).to.be.json;
@@ -742,6 +934,12 @@ describe('/api/bots/:id', () => {
                 it('returns a Bad Request status code', done => {
                     test().end((err, res) => {
                         expect(res).to.have.status(400);
+                        done();
+                    });
+                });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                         done();
                     });
                 });
@@ -764,6 +962,12 @@ describe('/api/bots/:id', () => {
                         done();
                     });
                 });
+                it('has a permissive CORS header', done => {
+                    test().end((err, res) => {
+                        expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                        done();
+                    });
+                });
                 it('returns a correct error JSON body', done => {
                     test().end((err, res) => {
                         expect(res).to.be.json;
@@ -783,6 +987,12 @@ describe('/api/bots/:id', () => {
             it('returns an OK status code', done => {
                 test().end((err, res) => {
                     expect(res).to.have.status(200);
+                    done();
+                });
+            });
+            it('has a permissive CORS header', done => {
+                test().end((err, res) => {
+                    expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                     done();
                 });
             });
@@ -890,6 +1100,12 @@ describe('/api/bots/:id', () => {
                 done();
             });
         });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+                done();
+            });
+        });
         it('returns an error JSON body', done => {
             test().end((err, res) => {
                 expect(res).to.be.json;
@@ -908,6 +1124,12 @@ describe('/api/legacy-ids', () => {
         it('returns an OK status code', done => {
             test().end((err, res) => {
                 expect(res).to.have.status(200);
+                done();
+            });
+        });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                 done();
             });
         });
@@ -969,6 +1191,12 @@ describe('/api/legacy-ids', () => {
         it('returns a Not Found status code', done => {
             test().end((err, res) => {
                 expect(res).to.have.status(404);
+                done();
+            });
+        });
+        it('has a permissive CORS header', done => {
+            test().end((err, res) => {
+                expect(res).to.have.header('Access-Control-Allow-Origin', '*');
                 done();
             });
         });

--- a/test/Routes/API.js
+++ b/test/Routes/API.js
@@ -1066,6 +1066,8 @@ describe('/api/bots/:id', () => {
                 test().end((err, res) => {
                     expect(res.body).to.have.property('id', '12345678901234567890');
                     expect(res.body).to.have.property('cached', true);
+                    expect(res.body).to.have.property('cache_expires_at');
+                    expect(res.body).to.have.property('cache_expires_in');
                     done();
                 });
             });

--- a/test/Routes/API.js
+++ b/test/Routes/API.js
@@ -1018,6 +1018,23 @@ describe('/api/bots/:id', () => {
                     expect(res.body).to.have.property('invite');
                     expect(res.body.invite).to.be.a('string');
 
+                    expect(res.body).to.have.property('prefix');
+                    expect(res.body.prefix).to.be.a('string');
+
+                    expect(res.body).to.have.property('website');
+                    expect(res.body.website).to.be.a('string');
+                    expect(res.body.website).equal('https://altdentifier.com');
+
+                    expect(res.body).to.have.property('github');
+                    expect(res.body.github).to.be.a('string');
+
+                    expect(res.body).to.have.property('support');
+                    expect(res.body.support).to.be.a('string');
+
+                    expect(res.body).to.have.property('library');
+                    expect(res.body.library).to.be.a('string');
+                    expect(res.body.library).equal('discord.py');
+
                     expect(res.body).to.have.property('list_data');
                     expect(res.body.list_data).to.be.an('object');
 

--- a/test/base.js
+++ b/test/base.js
@@ -14,7 +14,7 @@ const request = () => chai.request(target);
 const ratelimitBypass = (req) => req.set('X-Ratelimit-Bypass', config.secret);
 const resetRatelimits = () => ratelimitBypass(request().get('/api/reset'));
 
-const ratelimitTest = (context, limit, test, done) => {
+const ratelimitTest = (context, limit, test, done, status = 200) => {
     context.retries(0);
     context.slow((limit * 1.15 + 1.5) * 1000);
     context.timeout((limit * 1.25 + 3) * 1000);
@@ -23,7 +23,7 @@ const ratelimitTest = (context, limit, test, done) => {
         });
         setTimeout(() => {
             test().end((err, res) => {
-                expect(res).to.have.status(200);
+                expect(res).to.have.status(status);
                 expect(res).to.be.json;
                 done();
             });


### PR DESCRIPTION
 - Add CORS headers to all API responses
 - Update the get bot endpoint
   - Filter owners to be unque snowflakes only
   - Add parsed prefix
   - Add parsed website url
   - Add parsed github url
   - Add parsed support url
   - Add parsed library
 - Fix how caching works
   - Fix: Correct expiry query
   - Fix: Cache check before ratelimits applied
   - Documented caching in API docs